### PR TITLE
allow bot_spam channel

### DIFF
--- a/patroll.yml
+++ b/patroll.yml
@@ -15,4 +15,5 @@ target_commands:
 allowed_channels:
 #  - "experiment" # 開発用
 #  - "register-room"
+  - "bot_spam"
   - "bot_spam2"

--- a/patroll.yml
+++ b/patroll.yml
@@ -15,5 +15,5 @@ target_commands:
 allowed_channels:
 #  - "experiment" # 開発用
 #  - "register-room"
-  - "bot_spam"
-  - "bot_spam2"
+  - "bot-spam"
+  - "bot-spam2"


### PR DESCRIPTION
### 何を解決するのか

運営で ,balance を許可しているチャンネルが xpfiat に反映されていないので追加します。

### レビューポイント

- bot_spam チャンネルでも許可します

