### PR TITLE
コマンドを指定ちゃんねるのみに制限する

### DIFF
--- a/command_bot_ext.rb
+++ b/command_bot_ext.rb
@@ -1,0 +1,9 @@
+class CommandBotExt < Discordrb::Commands::CommandBot
+
+  # commandの実行をallowed_channelsのみに制限する
+  # @param name [Symbol] 対象のコマンド.
+  # @param allowed_channels [Array<String, Integer, Channel>] このチャンネルのみ許可される.
+  def set_channel_restriction(name, allowed_channels)
+    @commands[name.to_sym].attributes[:channels] = allowed_channels
+  end
+end

--- a/command_permissions.yml.sample
+++ b/command_permissions.yml.sample
@@ -1,0 +1,10 @@
+commands:
+  -
+    command_name: doge
+    allowed_channels:
+      - chat_1
+      - chat_2
+  -
+    command_name: ng
+    allowed_channels:
+      - chat_1

--- a/command_permissions.yml.sample
+++ b/command_permissions.yml.sample
@@ -1,10 +1,15 @@
+# 犬系コマンドをchat_1に限定する例
+
 commands:
   -
     command_name: doge
     allowed_channels:
       - chat_1
-      - chat_2
   -
-    command_name: ng
+    command_name: "犬"
+    allowed_channels:
+      - chat_1
+  -
+    command_name: "イッヌ"
     allowed_channels:
       - chat_1

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -2,9 +2,11 @@ require 'discordrb'
 require 'mechanize'
 require 'json'
 require './command_patroller'
+require './command_bot_ext'
 require 'dotenv/load'
+require 'yaml'
 
-bot = Discordrb::Commands::CommandBot.new token: ENV["TOKEN"], client_id: ENV["CLIENT_ID"], prefix:'?'
+bot = CommandBotExt.new token: ENV["TOKEN"], client_id: ENV["CLIENT_ID"], prefix:'?'
 
 module JoinAnnouncer
   extend Discordrb::EventContainer
@@ -234,6 +236,14 @@ bot.message(containing: ",register") do |event|
   bs = event.server.text_channels.select { |c| c.name == "bot_spam2" }.first
   event.respond "#{event.user.mention} ウォレットは登録されました。 #{bs.mention} で`,balance`をして確認してください。"
 end
+
+
+# commandを使えるchannelを制限する
+command_permissions = YAML.load_file("./command_permissions.yml")
+command_permissions["commands"].each do |command|
+  bot.set_channel_restriction(command["command_name"], command["allowed_channels"])
+end
+
 
 bot.include! JoinAnnouncer
 bot.include! CommandPatroller


### PR DESCRIPTION
### 何を解決するのか

#26 についての改修案です。
`command_permissions.yml` に、コマンドとそのコマンドを使えるチャンネルを設定します。
`bot.command :doge ~` 等しているもの全てに対応する必要があるので冗長ですが…

### レビューポイント

Discordrb::Commands::CommandBotを継承したクラスで@commands[name.to_sym].attributes[:channels]
を設定しています。
ほんとはbot.include!とかしたいのですが詳しくなく断念…

よろしくお願いいたします！


追記：
`command_permissions.yml.sample` → `command_permissions.yml` にしてお使いください。