### PR TITLE
Use rubocop on CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/LineLength:
   Max: 120
 
 # メソッドの最大行数
-Style/MethodLength:
+Metrics/MethodLength:
   Max: 20
   CountComments: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AsciiComments:
   Enabled: false
 
 # private/protected は一段深くインデントする
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   EnforcedStyle: rails
 
 # 1 行の最大文字数。

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.4.3
 bundler_args: "-j4"
 cache: bundler
-script: echo 'Hello, Trabis'
+script: bundle exec rubocop -a
 after_success:
   - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,8 @@ gem "discordrb"
 gem "dotenv"
 gem "json"
 gem "mechanize"
-gem "rspec", group: :test
-gem "rubocop", group: [:development, :test]
+
+group :development, :test do
+  gem "rspec"
+  gem "rubocop"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem "dotenv"
 gem "json"
 gem "mechanize"
 gem "rspec", group: :test
-gem "rubocop", group: :development
+gem "rubocop", group: [:development, :test]

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -22,7 +22,7 @@ end
 # TODO:新しいコマンド追加した場合は下記ヘルプに追加して下さい。
 bot.command :help do |event|
   event.channel.send_embed do |embed|
-    help = <<-"EOS"
+    help = <<-HEREDOC
       Commands:
       ?xp_jpy 1XPの日本円換算
       ?xp_jpy [amount] amount分のXPの日本円換算
@@ -34,7 +34,7 @@ bot.command :help do |event|
       ?yk or ?諭吉 一万円で買えるXPの量
       ?doge or ?犬 1DOGEで買えるXPの量
       ?how_rain 降雨量の追加(直近100メッセージ)
-    EOS
+    HEREDOC
 
     embed.description = help
   end


### PR DESCRIPTION
### 何を解決するのか

rubocop の警告の対応と CI への導入をします

### レビューポイント

- `.rubocop.yml` の古い表記を更新しました
- Travis でチェックするようにしました
- EOS → HEREDOC
