### PR TITLE
負荷軽減のためにRateLimiterを使う

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -8,6 +8,12 @@ require "dotenv/load"
 
 bot = Discordrb::Commands::CommandBot.new token: ENV["TOKEN"], client_id: ENV["CLIENT_ID"], prefix: ["?", "？"]
 
+# 連続のコマンド実行を制限する設定。以下は10秒以内に1回に制限する例。TODO あとでコメント直すor消す
+general_rate_limiter = Discordrb::Commands::SimpleRateLimiter.new
+general_rate_limiter.bucket(:general, limit: 1, time_span: 10, delay: 0)
+bot.include_buckets(general_rate_limiter)
+rate_limit_message = "連続して?コマンドは使えないよ。ちょっと待ってね!"
+
 module JoinAnnouncer
   extend Discordrb::EventContainer
 
@@ -188,7 +194,8 @@ def doge(event)
   event.respond "#{event.user.mention} イッヌ「わい一匹で、#{amount.to_i} くらいXPが買えるワン」"
 end
 
-bot.command [:doge, :犬, :イッヌ] { |event| doge(event) }
+# 犬系コマンドをrate_limitする例。TODO 後でコメント消す
+bot.command [:doge, :犬, :イッヌ], {rate_limit_message: rate_limit_message, bucket: :general} { |event| doge(event) }
 
 # -----------------------------------------------------------------------------
 bot.command [:今何人] { |event| event.respond "#{event.user.mention} ここのメンバーはいま #{event.server.member_count}人だよーん" }


### PR DESCRIPTION
### 何を解決するのか

#25 RateLimiterを使用して連続してコマンドを使用されないようにしました。
例として、犬を10秒以内に1回だけ許可するようにしています。

### レビューポイント

お作法的なところもびしばし指摘してください！
@xpjp/ruby-reviewer よろしくお願いいたします:pray: