### PR TITLE
Fix type error in xp_jpy

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -71,7 +71,7 @@ def read_price_from_json(coin_name, json)
 end
 
 def xp_jpy
-  read_price(:xp_doge) * read_price(:doge_btc) * read_price(:btc_jpy)
+  read_price(:xp_doge).to_f * read_price(:doge_btc).to_f * read_price(:btc_jpy).to_f
 end
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### 何を解決するのか

`xp_jpy`メソッド内で
```
Exception: #<TypeError: no implicit conversion of String into Integer>
```
なエラーが起きていたので修正する。

### レビューポイント

- `xp_jpy`の中で呼んでいる`read_price`の中で`to_f`するか迷ったが、他の箇所でも`read_price`が呼ばれていたので(デグレしないようにするのは今なら容易だが)、いったん`xp_jpy`内で愚直に対応した

