### PR TITLE
Add ping command

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -251,6 +251,10 @@ bot.command [:doge, :犬, :イッヌ] { |event| doge(event) }
 # -----------------------------------------------------------------------------
 bot.command [:今何人] { |event| event.respond "#{event.user.mention} :xpchan01:＜ ここには今#{event.server.member_count}人いるよ〜" }
 
+# -----------------------------------------------------------------------------
+# ping-pong
+bot.command [:ping], channels: ["bot_control"] { |event| event.respond "pong" }
+
 bot.message(containing: "ボットよ！バランスを確認せよ！") { |event| event.respond ",balance" }
 
 bot.message(containing: ",register") do |event|


### PR DESCRIPTION
### 何を解決するのか

デバッグ用にpingコマンドが欲しかったので追加しました。
主にBotの生存確認用途に使う想定です。
濫用を防ぐため、`bot_control`チャンネルでのみコマンドを受け付けるようにしました。

### レビューポイント

@xpjp/ruby-reviewer レビューよろしくお願いします！
