### PR TITLE
BOTのステータス欄に現在のXP価格を表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "discordrb"
 gem "dotenv"
 gem "json"
 gem "mechanize"
+gem "rufus-scheduler"
 
 group :development, :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
+    et-orbi (1.0.8)
+      tzinfo
     event_emitter (0.2.6)
     ffi (1.9.18)
     http-cookie (1.0.3)
@@ -72,6 +74,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rufus-scheduler (3.4.2)
+      et-orbi (~> 1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -92,6 +99,7 @@ DEPENDENCIES
   mechanize
   rspec
   rubocop
+  rufus-scheduler
 
 BUNDLED WITH
    1.16.0

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -5,6 +5,7 @@ require "mechanize"
 require "json"
 require "./command_patroller"
 require "dotenv/load"
+require "rufus-scheduler"
 
 bot = Discordrb::Commands::CommandBot.new token: ENV["TOKEN"], client_id: ENV["CLIENT_ID"], prefix: ["?", "？"]
 
@@ -256,6 +257,13 @@ bot.message(containing: "ボットよ！バランスを確認せよ！") { |even
 bot.message(containing: ",register") do |event|
   bs = event.server.text_channels.select { |c| c.name == "bot_spam2" }.first
   event.respond "#{event.user.mention} ウォレットは登録されました。 #{bs.mention} で`,balance`をして確認してください。"
+end
+
+# -----------------------------------------------------------------------------
+# update BOT status periodically
+scheduler = Rufus::Scheduler.new
+scheduler.in "5m" do
+  bot.update_status(:online, "だいたい#{format("%.3f", xp_jpy)}円だよ〜", nil)
 end
 
 bot.include! JoinAnnouncer


### PR DESCRIPTION
### 何を解決するのか

`?いくら`の使用を抑制するため、Botのステータス欄（xxxをプレイ中）を定期的にXP-JPYで更新するようにしました。
多分`mod_request`チャンネルで出ていた案です。
とりあえず5分インターバルにしています。

### レビューポイント

gem追加しちゃってますが問題ないでしょうか？
@xpjp/ruby-reviewer レビューよろしくお願いいたします。

### 追記
@macchkyさんの案でした。