### PR TITLE
BOTのステータス更新スケジューラが1度で止まらないように修正

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -293,7 +293,7 @@ end
 # -----------------------------------------------------------------------------
 # update BOT status periodically
 scheduler = Rufus::Scheduler.new
-scheduler.in "5m" do
+scheduler.every "5m" do
   bot.update_status(:online, "だいたい#{format("%.3f", xp_jpy)}円だよ〜", nil)
 end
 


### PR DESCRIPTION
### 何を解決するのか

BOT起動5分後に1度だけしか動かなかったので5分毎に動き続けるようにした

### レビューポイント

すでに本番は @p-suke さんに修正していただいちゃってますので後追いプルリクです（死にたい
@xpjp/ruby-reviewer レビューよろしくお願いいたします
