### PR TITLE
Fix #68 文頭に`,register`がある場合だけ反応するように修正

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -285,7 +285,7 @@ bot.command [:ping], channels: ["bot_control"] { |event| event.respond "pong" }
 
 bot.message(containing: "ボットよ！バランスを確認せよ！") { |event| event.respond ",balance" }
 
-bot.message(containing: ",register") do |event|
+bot.message(start_with: ",register") do |event|
   bs = event.server.text_channels.select { |c| c.name == "bot_spam2" }.first
   event.respond "#{event.user.mention} ウォレットは登録されました。 #{bs.mention} で`,balance`をして確認してください。"
 end


### PR DESCRIPTION
### 何を解決するのか

#68 文頭の `,register` にだけ反応するようにしました。

### レビューポイント

@xpjp/ruby-reviewer よろしくお願いいたします。