### PR TITLE
aiとのchatにembedを使用し、顔画像をつける機能の追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,6 @@ Style/Documentation:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-# ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦19とする)
+# ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦17とする)
 Metrics/AbcSize:
-  Max: 19
+  Max: 1７

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,6 @@ Style/Documentation:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-# ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦17とする)
+# ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦19とする)
 Metrics/AbcSize:
-  Max: 17
+Max: 19

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,4 +39,4 @@ Lint/UnderscorePrefixedVariableName:
 
 # ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦19とする)
 Metrics/AbcSize:
-Max: 19
+  Max: 19

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-gem 'activesupport'
-gem 'discordrb'
-gem 'dotenv'
-gem 'json'
-gem 'mechanize'
-gem 'natto'
-gem 'negapoji', git: 'git://github.com/hatt0519/negapoji.git'
-gem 'rmagick'
-gem 'rufus-scheduler'
+gem "activesupport"
+gem "discordrb"
+gem "dotenv"
+gem "json"
+gem "mechanize"
+gem "natto"
+gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
+gem "rmagick"
+gem "rufus-scheduler"
 
 group :development, :test do
-  gem 'rspec'
-  gem 'rubocop'
+  gem "rspec"
+  gem "rubocop"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,10 @@ gem "discordrb"
 gem "dotenv"
 gem "json"
 gem "mechanize"
+gem "natto"
+gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
 gem "rmagick"
 gem "rufus-scheduler"
-gem "natto"
-gem "negapoji" ,:git => 'git://github.com/hatt0519/negapoji.git'
-
-
 
 group :development, :test do
   gem "rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-gem "activesupport"
-gem "discordrb"
-gem "dotenv"
-gem "json"
-gem "mechanize"
-gem "natto"
-gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
-gem "rmagick"
-gem "rufus-scheduler"
+gem 'activesupport'
+gem 'discordrb'
+gem 'dotenv'
+gem 'json'
+gem 'mechanize'
+gem 'natto'
+gem 'negapoji', git: 'git://github.com/hatt0519/negapoji.git'
+gem 'rmagick'
+gem 'rufus-scheduler'
 
 group :development, :test do
-  gem "rspec"
-  gem "rubocop"
+  gem 'rspec'
+  gem 'rubocop'
 end

--- a/command_patroller.rb
+++ b/command_patroller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'yaml'
+require "yaml"
 
 # 規定のチャネル以外で ,balance 等のコマンドを実行した場合にその人にメンションする機能
 # 監視するチャネルとコマンド、及び警告メッセージの内容はpatroll.ymlに記述
@@ -9,13 +9,13 @@ require 'yaml'
 # NOTE: 本来は本家Botで対処したいところ（そうすれば上記のようなことはしなくて良い）
 module CommandPatroller
   extend Discordrb::EventContainer
-  @patroll_config = YAML.load_file('./patroll.yml')
+  @patroll_config = YAML.load_file("./patroll.yml")
   message do |event|
     # apiの仕様的に存在しないことが保証されているかわからなかったので、落ちないように一応ガード節
     break if !event.message || !event.channel || !event.user
 
-    needs_to_warn = @patroll_config['target_commands'].include?(event.message.content) &&
-                    !@patroll_config['allowed_channels'].include?(event.channel.name) # railsのexclude?使いたい
-    event.respond "#{event.user.mention} #{@patroll_config['warning_text']}" if needs_to_warn
+    needs_to_warn = @patroll_config["target_commands"].include?(event.message.content) &&
+                    !@patroll_config["allowed_channels"].include?(event.channel.name) # railsのexclude?使いたい
+    event.respond "#{event.user.mention} #{@patroll_config["warning_text"]}" if needs_to_warn
   end
 end

--- a/command_patroller.rb
+++ b/command_patroller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "yaml"
+require 'yaml'
 
 # 規定のチャネル以外で ,balance 等のコマンドを実行した場合にその人にメンションする機能
 # 監視するチャネルとコマンド、及び警告メッセージの内容はpatroll.ymlに記述
@@ -9,13 +9,13 @@ require "yaml"
 # NOTE: 本来は本家Botで対処したいところ（そうすれば上記のようなことはしなくて良い）
 module CommandPatroller
   extend Discordrb::EventContainer
-  @patroll_config = YAML.load_file("./patroll.yml")
+  @patroll_config = YAML.load_file('./patroll.yml')
   message do |event|
     # apiの仕様的に存在しないことが保証されているかわからなかったので、落ちないように一応ガード節
     break if !event.message || !event.channel || !event.user
 
-    needs_to_warn = @patroll_config["target_commands"].include?(event.message.content) &&
-                    !@patroll_config["allowed_channels"].include?(event.channel.name) # railsのexclude?使いたい
+    needs_to_warn = @patroll_config['target_commands'].include?(event.message.content) &&
+                    !@patroll_config['allowed_channels'].include?(event.channel.name) # railsのexclude?使いたい
     event.respond "#{event.user.mention} #{@patroll_config['warning_text']}" if needs_to_warn
   end
 end

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -323,7 +323,7 @@ def doge(event)
 end
 
 # 犬系コマンドをrate_limitする例。TODO 後でコメント消す
-#bot.command [:doge, :犬, :イッヌ], rate_limit_message: rate_limit_message, bucket: :general { |event| doge(event) }
+# bot.command [:doge, :犬, :イッヌ], rate_limit_message: rate_limit_message, bucket: :general { |event| doge(event) }
 
 # -----------------------------------------------------------------------------
 bot.command [:今何人] do |event|
@@ -400,12 +400,14 @@ def docomo_talk_plus(event:, message:, name:, type:)
   # embed_setting
   event.channel.send_embed do |embed|
     # embed_setting
-    embed.title = "#{name}"
+    embed.title = "#{name}to_s"
     embed.description = "#{event.user.mention}\n「#{utt}」"
     if emotion == "positive"
-      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQM_pppuatX_vvXw6ZDRQ_3GouyV9C0rrf8qMl1SlkYoDie6Y5l")
+      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: \
+        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQM_pppuatX_vvXw6ZDRQ_3GouyV9C0rrf8qMl1SlkYoDie6Y5l")
     else
-      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: "https://media.istockphoto.com/vectors/large-sad-crying-yellow-emoticon-cartoon-vector-id468900488")
+      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: \
+        "https://media.istockphoto.com/vectors/large-sad-crying-yellow-emoticon-cartoon-vector-id468900488")
     end
   end
 end

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -7,7 +7,7 @@ require "net/http"
 require "uri"
 require "./command_patroller"
 require "dotenv/load"
-require "rmagick"
+require "RMagick"
 require "rufus-scheduler"
 require "active_support"
 require "active_support/core_ext/numeric/conversions"
@@ -19,6 +19,7 @@ bot = Discordrb::Commands::CommandBot.new token: ENV["TOKEN"], client_id: ENV["C
 general_rate_limiter = Discordrb::Commands::SimpleRateLimiter.new
 general_rate_limiter.bucket(:general, limit: 1, time_span: 10, delay: 0)
 bot.include_buckets(general_rate_limiter)
+rate_limit_message = "連続して?コマンドは使えないよ。ちょっと待ってね!"
 
 module JoinAnnouncer
   extend Discordrb::EventContainer
@@ -236,7 +237,7 @@ def join_sentence(sentences)
   sentence
 end
 
-def blue_mix_translate(sentence, model:)
+def blue_mix_translate(event, sentence, model:)
   body = {
     "model_id": model,
     "text": sentence
@@ -250,7 +251,7 @@ def blue_mix_translate(sentence, model:)
   additional_headers = {
     "content-type" => "application/json"
   }
-# TODO: エラー対応
+# TODO:エラー対応
   uri_translate = "#{uri}/v2/translate"
   response = agent.post(uri_translate, body, additional_headers)
   JSON.parse(response.body)["translations"][0]["translation"]
@@ -323,7 +324,7 @@ def doge(event)
 end
 
 # 犬系コマンドをrate_limitする例。TODO 後でコメント消す
-# bot.command [:doge, :犬, :イッヌ], rate_limit_message: rate_limit_message, bucket: :general { |event| doge(event) }
+bot.command [:doge, :犬, :イッヌ], rate_limit_message: rate_limit_message, bucket: :general { |event| doge(event) }
 
 # -----------------------------------------------------------------------------
 bot.command [:今何人] do |event|

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -48,6 +48,7 @@ bot.command :help do |event|
       ?doge or ?犬 1DOGEで買えるXPの量
       ?how_rain 降雨量の追加(直近100メッセージ)
       ?talk_ai [message] AIと対話できます
+      ?ta_plus [message] AIと会話(顔付き)
     HEREDOC
 
     embed.description = help
@@ -237,7 +238,7 @@ def join_sentence(sentences)
   sentence
 end
 
-def blue_mix_translate(event, sentence, model:)
+def blue_mix_translate(sentence, model:)
   body = {
     "model_id": model,
     "text": sentence
@@ -251,7 +252,7 @@ def blue_mix_translate(event, sentence, model:)
   additional_headers = {
     "content-type" => "application/json"
   }
-# TODO:エラー対応
+# TODO: エラー対応
   uri_translate = "#{uri}/v2/translate"
   response = agent.post(uri_translate, body, additional_headers)
   JSON.parse(response.body)["translations"][0]["translation"]

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -19,7 +19,6 @@ bot = Discordrb::Commands::CommandBot.new token: ENV["TOKEN"], client_id: ENV["C
 general_rate_limiter = Discordrb::Commands::SimpleRateLimiter.new
 general_rate_limiter.bucket(:general, limit: 1, time_span: 10, delay: 0)
 bot.include_buckets(general_rate_limiter)
-rate_limit_message = "連続して?コマンドは使えないよ。ちょっと待ってね!"
 
 module JoinAnnouncer
   extend Discordrb::EventContainer

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -236,7 +236,7 @@ def join_sentence(sentences)
   sentence
 end
 
-def blue_mix_translate(event, sentence, model:)
+def blue_mix_translate(sentence, model:)
   body = {
     "model_id": model,
     "text": sentence
@@ -250,7 +250,7 @@ def blue_mix_translate(event, sentence, model:)
   additional_headers = {
     "content-type" => "application/json"
   }
-# TODO:エラー対応
+# TODO: エラー対応
   uri_translate = "#{uri}/v2/translate"
   response = agent.post(uri_translate, body, additional_headers)
   JSON.parse(response.body)["translations"][0]["translation"]


### PR DESCRIPTION
### 機能
negapojiによってaiとのチャットのメッセージを解析し、
embedの機能を使い感情によって表示される顔が変わるようにしたい。

### レビューポイント
url指定する所などが長くなってしまっているかもしれないです

### 改良点
・雑談対話botのプログラムを丸ごと使わさせていただきましたが、
  全く同じ機能の関数を違う名前で再定義していたのであとで修正しておきます。
・表示する画像をテスト画像のurlそのままであげてしまっていたのでxp-chan関係でいい画像を探してくる
  or書いておきます
