### PR TITLE
xp2jpy出力の小数点以下を４桁に変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,4 +39,4 @@ Lint/UnderscorePrefixedVariableName:
 
 # ABCSize(デフォルトの15だと本プロジェクトには少し厳しいかなと思うので一旦17とする)
 Metrics/AbcSize:
-  Max: 17
+  Max: 17.5

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -50,10 +50,10 @@ def xp2jpy(event, param1)
     if (amount = param1.to_i).positive?
       _xp_jpy = xp_jpy * amount
       "#{event.user.mention} <:xpchan01:391497596461645824>\
-＜ #{amount.to_s(:delimited)}XPはいま #{_xp_jpy.to_s(:delimited)} 円だよ〜"
+＜ #{amount.to_s(:delimited)}XPはいま #{_xp_jpy.round(4).to_s(:delimited)} 円だよ〜"
     else
-      _xp_jpy = xp_jpy.round(8)
-      "#{event.user.mention} <:xpchan01:391497596461645824>＜ 1XPはいま #{_xp_jpy.to_s(:delimited)} 円だよ〜"
+      _xp_jpy = xp_jpy
+      "#{event.user.mention} <:xpchan01:391497596461645824>＜ 1XPはいま #{_xp_jpy.round(4).to_s(:delimited)} 円だよ〜"
     end
   message ||= ":satisfied:"
   event.respond message


### PR DESCRIPTION
### 何を解決するのか
xp2jpy出力の小数点以下が長すぎて見づらかったので、４桁にしました。

### レビューポイント
・出力だけを変えているので、元の計算精度への影響は軽微と考えています。
・ABCsizeが0.12超過したので、17.5に変更しました。
