### PR TITLE
降雨量コマンド(?how_rain)の修正

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -145,7 +145,7 @@ def how_rain(event, max_history)
       # Xp-Bot の発言であれば、それがrainコマンドの成功のメッセージか確認する
       if message.content.include?("Brewing Storm")
         mention_to = message.mentions.first.id
-        if buffer.has_key?(mention_to)
+        if buffer.has_key?(mention_to) && buffer[mention_to].size >= 1
           # 対象ユーザーの発言も見つけているのでsumに足し、waitingから引く
           amount = buffer[mention_to].delete_at(0)
           sum += amount
@@ -154,7 +154,7 @@ def how_rain(event, max_history)
       elsif message.content.include?("min rain amount is") || message.content.include?("Insufficient Balance")
         mention_to = message.mentions.first.id
         # 失敗メッセージ -> 消すだけ
-        if buffer[mention_to].size >= 1
+        if buffer.has_key?(mention_to) && buffer[mention_to].size >= 1
           amount = buffer[mention_to].delete_at(0)
           waiting -= amount
         end


### PR DESCRIPTION
### 何を解決するのか

?how_rainにおいて、空rainがカウントされている問題に対応。
伴って、未確定なrainを区別して出力するようにした。

・Botがまだ反応していない発言の区別
・Botがエラーを返したコマンドの区別
　・min rain amount is ***
　・Insufficient Balance
・出力を「確定」「Bot待ち」の2種類に変更

### レビューポイント

Xp-Botの発言に対しての反応を追加している形なので、
そのあたりで漏れなどがないか？
（数量指定が低い、残高がない、という問題は対応した）
出力メッセージが適切かどうか？