### PR TITLE
?いくら command で小数点以下を切り捨てるように修正

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -47,10 +47,10 @@ end
 # -----------------------------------------------------------------------------
 def xp2jpy(event, param1)
   message =
-    if (amount = param1.to_f).positive?
+    if (amount = param1.to_i).positive?
       _xp_jpy = xp_jpy * amount
       "#{event.user.mention} <:xpchan01:391497596461645824>\
-＜ #{amount.to_i.to_s(:delimited)}XPはいま #{_xp_jpy.to_s(:delimited)} 円だよ〜"
+＜ #{amount.to_s(:delimited)}XPはいま #{_xp_jpy.to_s(:delimited)} 円だよ〜"
     else
       _xp_jpy = xp_jpy.round(8)
       "#{event.user.mention} <:xpchan01:391497596461645824>＜ 1XPはいま #{_xp_jpy.to_s(:delimited)} 円だよ〜"


### PR DESCRIPTION
### 何を解決するのか
1XP が100円だと仮定したときに

`?いくら 1.99` => < 1XPはいま 199円だよ〜
`?いくら 1` => < 1XP はいま 100円だよ〜

このように嘘の情報が流れてしまい、ユーザーが混乱しているため、小数点を切り捨てて計算するように修正しました。

### レビューポイント
上記の想定通りに動けば OK です。
