### PR TITLE
降雨量コマンド(?how_rain)について空Rainに反応しないように変更

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -62,16 +62,25 @@ end
 # -----------------------------------------------------------------------------
 def how_rain(event, max_history)
   messages = event.channel.history(max_history)
-  sum = 0
+  sum = 0.0
   messages.each do |message|
-    next unless message.content.include?(",rain")
-    divided_message = message.content.split(" ")
-    if divided_message.length >= 2
-      amount = divided_message[1].to_i
-      sum += amount
+    # Xp-Bot以外は無視 (一般ユーザーのRainedコピペなどに反応しないように)
+    next if message.author.id != 352815000257167362
+
+    # 正規表現で、ユーザーあたりのXPとユーザー数を取得し、乗算して合計する
+    # 本家Botの出力が変わったら計算できないのでその場合は更新すること
+    if message.content =~ /Rained:\s(\d+\.?\d*)\sTo:\s(\d+)\s/
+      amount = $1.to_f * $2.to_i
+      sum += amount.round(7) # 第七位までで四捨五入、整数のrainであれば整数になるはず
     end
   end
-  event.send_message("只今の降雨量は #{sum.to_s(:delimited)} Xpです。")
+  if sum.to_i == sum
+    # ぴったり整数になるようであれば、intにしてからstringにする
+    event.send_message("只今の降雨量は #{sum.to_i.to_s(:delimited)} Xpです。")
+  elsif
+    # 整数でないrainがあった場合、加算した際に誤差の問題で桁が大きくなっていることがあるのでここでもround
+    event.send_message("只今の降雨量は #{sum.round(7).to_s(:delimited)} Xpです。")
+  end
 end
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### 何を解決するのか

降雨量コマンド(?how_rain)について、Botのレスポンス側を見るように変更し、
空Rainに反応しないように変更します。

fix #86

### レビューポイント

今回の実装では、Issue #86での議論の結果、
Rainedメッセージをパースし、「ユーザーあたりのXP数 * 配布対象ユーザー数」を算出、
小数点第8位を四捨五入し、その合計を降雨量としています。
（第8位とした根拠：GameBalanceの表示桁数に合わせ、第7位までの取得とした）

上記通りになっているかどうか、レビューをお願いします。

注）このリクエスト現在、Xp-Botが停止しているので、Botの識別に使用したIDについて確認できません。控えていたので問題ないとは思いますが、復旧待ちでしょうか。
→ オフラインでも「IDをコピー」はできましたね・・・。352815000257167362で間違いありませんでした。