### PR TITLE
ステータス欄のXPレート表示部分にレート取得日時を追加

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -5,6 +5,7 @@ require "mechanize"
 require "net/http"
 require "active_support"
 require "active_support/core_ext/numeric/conversions"
+require "active_support/core_ext/time/calculations"
 require "active_support/dependencies"
 require "./lib/bot_controller"
 
@@ -140,7 +141,8 @@ bc.include! Actions::Messages::Hayo
 bc.include! Actions::Messages::Wayo
 
 bc.add_schedule "5m" do |bot|
-  bot.update_status(:online, "だいたい#{format('%.3f', xp_jpy.to_s(:delimited))}円だよ〜", nil)
+  _time_now = Time.now.in_time_zone("Asia/Tokyo")
+  bot.update_status(:online, "#{format('%.3f', xp_jpy.to_s(:delimited))}円 (#{_time_now.to_s(:db)})", nil)
 end
 
 bc.run


### PR DESCRIPTION
### 何を解決するのか

BOTのステータス欄に表示しているレートがいつ時点のものかわかるように日時を合わせて表示するようにした。

### レビューポイント

rubocopは黙らせました。
@xpjp/ruby-reviewer よろしくお願いいたします。
