### PR TITLE
時価総額を返すbotを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "natto"
 gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
 gem "rmagick"
 gem "rufus-scheduler"
+gem "number_to_yen"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "natto"
 gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
 gem "rmagick"
 gem "rufus-scheduler"
+gem "yen"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "natto"
 gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
 gem "rmagick"
 gem "rufus-scheduler"
-gem "yen"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem "json"
 gem "mechanize"
 gem "natto"
 gem "negapoji", git: "git://github.com/hatt0519/negapoji.git"
+gem "number_to_yen"
 gem "rmagick"
 gem "rufus-scheduler"
-gem "number_to_yen"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
-    yen (0.0.2)
 
 PLATFORMS
   ruby
@@ -134,7 +133,6 @@ DEPENDENCIES
   rspec
   rubocop
   rufus-scheduler
-  yen
 
 BUNDLED WITH
    1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     ntlm-http (0.1.1)
+    number_to_yen (0.1.1)
     opus-ruby (1.0.1)
       ffi
     parallel (1.12.1)
@@ -128,6 +129,7 @@ DEPENDENCIES
   mechanize
   natto
   negapoji!
+  number_to_yen
   pry-byebug
   rmagick
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
+    yen (0.0.2)
 
 PLATFORMS
   ruby
@@ -133,6 +134,7 @@ DEPENDENCIES
   rspec
   rubocop
   rufus-scheduler
+  yen
 
 BUNDLED WITH
    1.16.0

--- a/lib/actions/commands/market_cap.rb
+++ b/lib/actions/commands/market_cap.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "discordrb"
+
+module Actions
+  module Commands
+    # XPの円換算した時価総額を返すコマンド
+    module MarketCap
+      extend Discordrb::Commands::CommandContainer
+
+      rate_limit_message = "連続して?コマンドは使えないよ。ちょっと待ってね!"
+
+      command [:mcap, :時価総額, :戦闘力], rate_limit_message: rate_limit_message, bucket: :general do |event|
+        market_cap(event)
+      end
+    end
+  end
+end

--- a/lib/actions/commands/market_cap.rb
+++ b/lib/actions/commands/market_cap.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "discordrb"
+require "number_to_yen"
 
 module Actions
   module Commands
     # XPの円換算した時価総額を返すコマンド
     module MarketCap
       extend Discordrb::Commands::CommandContainer
-
+      extend NumberToYen
       rate_limit_message = "連続して?コマンドは使えないよ。ちょっと待ってね!"
 
       command [:mcap, :時価総額, :戦闘力], rate_limit_message: rate_limit_message, bucket: :general do |event|

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -119,15 +119,14 @@ end
 
 # -----------------------------------------------------------------------------
 def to_j(int_jpy)
-  # insertは破壊的なメソッドなので元の文字列が変化しないようにコピー
-  dup_str = int_jpy.to_s
-  # 後ろから5番目("123456789円"の"5"の後ろに"万"を挿入)
-  dup_str.insert(-5, '万') if dup_str.length >= 5
-  # 後ろから10番目("12345万6789円"の"1"の後ろに"億"を挿入)
-  dup_str.insert(-10, '億') if dup_str.length >= 10
-  # 後ろから15番目("6兆7891億2345万6789円"の"6"の後ろに"兆"を挿入)
-  dup_str.insert(-15, '兆') if dup_str.length >= 15
-  dup_str
+  price_int = int_jpy.to_i
+  return 0 unless price_int.positive?
+  price_str = price_int.to_s
+  digits = 1 + Math.log10(price_int) #ケタ数
+  price_str.insert(-5, '万') if digits >= 5
+  price_str.insert(-10, '億') if digits >= 10
+  price_str.insert(-15, '兆') if digits >= 15
+  price_str
 end
 
 # -----------------------------------------------------------------------------

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -7,6 +7,7 @@ require "active_support"
 require "active_support/core_ext/numeric/conversions"
 require "active_support/dependencies"
 require "./lib/bot_controller"
+require "yen"
 
 ActiveSupport::Dependencies.autoload_paths << "./lib"
 
@@ -26,6 +27,8 @@ def read_url(coin_name)
     "https://poloniex.com/public?command=returnTicker"
   when :btc_jpy
     "https://coincheck.com/api/rate/btc_jpy"
+  when :xp_mcap_jpy
+    "https://api.coinmarketcap.com/v1/ticker/xp/?convert=JPY"
   end
 end
 
@@ -37,6 +40,8 @@ def read_price_from_json(coin_name, json)
     json["BTC_DOGE"]["last"]
   when :btc_jpy
     json["rate"]
+  when :xp_mcap_jpy
+    json[0]["market_cap_jpy"]
   end
 end
 
@@ -113,6 +118,11 @@ def doge(event)
   event.respond "#{event.user.mention} <:doge:391497526278225920>＜ わい一匹で、#{amount.to_i.to_s(:delimited)} くらいXPが買えるワン"
 end
 
+def market_cap(event)
+  mcap_value = read_price(:xp_mcap_jpy)
+  event.respond "#{event.user.mention} <:xpchan01:391497596461645824>＜ 私の戦闘力は#{mcap_value.to_i.to_j}円 です"
+end
+
 bc = BotController.new
 
 bc.include_commands Actions::Commands::Ping, false
@@ -121,6 +131,7 @@ bc.include_commands Actions::Commands::Noguchi, "千円で買えるXPの量"
 bc.include_commands Actions::Commands::Higuchi, "五千円で買えるXPの量"
 bc.include_commands Actions::Commands::Yukichi, "一万円で買えるXPの量"
 bc.include_commands Actions::Commands::Doge, "1DOGEで買えるXPの量"
+bc.include_commands Actions::Commands::MarketCap, "XPの時価総額日本円換算"
 bc.include_commands Actions::Commands::XpJpy, ["1XPの日本円換算", "[amount] amount分のXPの日本円換算"]
 bc.include_commands Actions::Commands::JpyXp, "[amount] 日本円でどれだけ買えるか"
 bc.include_commands Actions::Commands::MakeImg, "[sentence] 半角スペースで改行 ノベルゲーム風の画像を生成"

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -9,7 +9,6 @@ require "active_support/core_ext/time/calculations"
 require "active_support/dependencies"
 require "./lib/bot_controller"
 require "number_to_yen"
-include NumberToYen
 ActiveSupport::Dependencies.autoload_paths << "./lib"
 
 # -----------------------------------------------------------------------------

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -7,7 +7,6 @@ require "active_support"
 require "active_support/core_ext/numeric/conversions"
 require "active_support/dependencies"
 require "./lib/bot_controller"
-require "yen"
 
 ActiveSupport::Dependencies.autoload_paths << "./lib"
 
@@ -118,9 +117,24 @@ def doge(event)
   event.respond "#{event.user.mention} <:doge:391497526278225920>＜ わい一匹で、#{amount.to_i.to_s(:delimited)} くらいXPが買えるワン"
 end
 
+# -----------------------------------------------------------------------------
+def to_j(int_jpy)
+  # insertは破壊的なメソッドなので元の文字列が変化しないようにコピー
+  dup_str = int_jpy.to_s
+  # 後ろから6番目("123456789円"の"5"の後ろに"万"を挿入)
+  dup_str.insert(-6, '万') if dup_str.length >= 6
+  # 後ろから11番目("12345万6789円"の"1"の後ろに"億"を挿入)
+  dup_str.insert(-11, '億') if dup_str.length >= 11
+  # 後ろから16番目("6兆7891億2345万6789円"の"6"の後ろに"兆"を挿入)
+  dup_str.insert(-16, '兆') if dup_str.length >= 16
+  dup_str
+end
+
+# -----------------------------------------------------------------------------
 def market_cap(event)
   mcap_value = read_price(:xp_mcap_jpy)
-  event.respond "#{event.user.mention} <:xpchan01:391497596461645824>＜ 私の戦闘力は#{mcap_value.to_i.to_j}円 です"
+  str_mcap_jpy = to_j(mcap_value.to_i)
+  event.respond "#{event.user.mention} <:xpchan01:391497596461645824>＜ 私の戦闘力は#{str_mcap_jpy}円 です"
 end
 
 bc = BotController.new

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -121,12 +121,12 @@ end
 def to_j(int_jpy)
   # insertは破壊的なメソッドなので元の文字列が変化しないようにコピー
   dup_str = int_jpy.to_s
-  # 後ろから6番目("123456789円"の"5"の後ろに"万"を挿入)
-  dup_str.insert(-6, '万') if dup_str.length >= 6
-  # 後ろから11番目("12345万6789円"の"1"の後ろに"億"を挿入)
-  dup_str.insert(-11, '億') if dup_str.length >= 11
-  # 後ろから16番目("6兆7891億2345万6789円"の"6"の後ろに"兆"を挿入)
-  dup_str.insert(-16, '兆') if dup_str.length >= 16
+  # 後ろから5番目("123456789円"の"5"の後ろに"万"を挿入)
+  dup_str.insert(-5, '万') if dup_str.length >= 5
+  # 後ろから10番目("12345万6789円"の"1"の後ろに"億"を挿入)
+  dup_str.insert(-10, '億') if dup_str.length >= 10
+  # 後ろから15番目("6兆7891億2345万6789円"の"6"の後ろに"兆"を挿入)
+  dup_str.insert(-15, '兆') if dup_str.length >= 15
   dup_str
 end
 

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -7,7 +7,8 @@ require "active_support"
 require "active_support/core_ext/numeric/conversions"
 require "active_support/dependencies"
 require "./lib/bot_controller"
-
+require "number_to_yen"
+include NumberToYen
 ActiveSupport::Dependencies.autoload_paths << "./lib"
 
 # -----------------------------------------------------------------------------
@@ -121,11 +122,7 @@ end
 def to_j(int_jpy)
   price_int = int_jpy.to_i
   return 0 unless price_int.positive?
-  price_str = price_int.to_s
-  digits = 1 + Math.log10(price_int) #ケタ数
-  price_str.insert(-5, '万') if digits >= 5
-  price_str.insert(-10, '億') if digits >= 10
-  price_str.insert(-15, '兆') if digits >= 15
+  price_str = number_to_yen(price_int)
   price_str
 end
 
@@ -133,7 +130,7 @@ end
 def market_cap(event)
   mcap_value = read_price(:xp_mcap_jpy)
   str_mcap_jpy = to_j(mcap_value.to_i)
-  event.respond "#{event.user.mention} <:xpchan01:391497596461645824>＜ 私の戦闘力は#{str_mcap_jpy}円 です"
+  event.respond "#{event.user.mention} <:xpchan01:391497596461645824>＜ 私の戦闘力は#{str_mcap_jpy} です"
 end
 
 bc = BotController.new


### PR DESCRIPTION
### 何を解決するのか
?mcap  ?時価総額 ?戦闘力 とコマンドを入力するとXPの現在の時価総額の日本円換算した金額を知ることができる。
issue
https://github.com/xpjp/xpfiat-bot/issues/49
### レビューポイント
・coinmarketcapのapiから時価総額の日本円換算を取得しread_urlメソッドに追記しました。
・時価総額の日本円換算で桁数が大きくなり分かりづらかったため、数値を日本語表記する
gemを導入しました。
https://github.com/xpjp/xpfiat-bot/issues/96
https://github.com/siman-man/yen

・時価総額をXPちゃんが「私の戦闘力は○○億○○万○○円です」と表示するように仮設定しました。
問題があれば、「XPの時価総額は---」に変更します。

@xpjp/ruby-reviewer 
ご確認をお願い致します。