### PR TITLE
?いくら コマンドで表示される URL を短くし、リンク先画像がTLに表示されないように修正

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -58,10 +58,10 @@ def xp2jpy(event)
     また、XPの日本円換算を知りたい方はクリプトフォリオをおすすめします。
 
     iOS
-    https://itunes.apple.com/jp/app/cryptofolio-%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA/id1272475312?mt=8
+    <https://goo.gl/WgyN6A>
 
     Android
-    https://play.google.com/store/apps/details?id=com.appruns.and.dist.cryptofolio&hl=ja
+    <https://goo.gl/vQBg8R>
   HEREDOC
   # rubocop:enable Style/FormatStringToken
   event.respond message


### PR DESCRIPTION
### 何を解決するのか
 - `?いくら` コマンドで表示される URL を短くしました。
 - リンク先画像がTLに表示されないようになります。

### イメージ
<img width="818" alt="2018-01-06 0 27 09" src="https://user-images.githubusercontent.com/10157007/34615505-7920a972-f278-11e7-8ac3-97295d70ef3d.png">

