### PR TITLE
日本円換算をcoinmarketcapから取得するようにしてみた

### DIFF
--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -47,7 +47,6 @@ end
 
 # -----------------------------------------------------------------------------
 def xp2jpy(event)
-  # rubocop:disable Style/FormatStringToken
   message = <<~HEREDOC
     #{event.user.mention}
     ただいま `?いくら` コマンドはサーバーへの過負荷により動作を停止しています。
@@ -136,13 +135,12 @@ bc.include! Actions::Events::JoinAnnouncer
 bc.include! Actions::Events::CommandPatroller
 
 bc.include! Actions::Messages::Balance
-#bc.include! Actions::Messages::Register
 bc.include! Actions::Messages::Hayo
 bc.include! Actions::Messages::Wayo
 
 bc.add_schedule "1m" do |bot|
   _time_now = Time.now.in_time_zone("Asia/Tokyo")
-  bot.update_status(:online, "#{format('%.3f', xp_jpy.to_s(:delimited))}円 [#{_time_now.strftime("%H:%M:%S")}]", nil)
+  bot.update_status(:online, "#{format('%.3f', xp_jpy.to_s(:delimited))}円 [#{_time_now.strftime('%H:%M:%S')}]", nil)
 end
 
 bc.run

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -145,9 +145,9 @@ bc.include! Actions::Messages::Register
 bc.include! Actions::Messages::Hayo
 bc.include! Actions::Messages::Wayo
 
-bc.add_schedule "5m" do |bot|
+bc.add_schedule "1m" do |bot|
   _time_now = Time.now.in_time_zone("Asia/Tokyo")
-  bot.update_status(:online, "#{format('%.3f', xp_jpy.to_s(:delimited))}円 (#{_time_now.to_s(:db)})", nil)
+  bot.update_status(:online, "#{format('%.3f', xp_jpy.to_s(:delimited))}円 [#{_time_now.strftime("%H:%M:%S")}]", nil)
 end
 
 bc.run

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -32,10 +32,6 @@ def read_price_from_json(coin_name, json)
   case coin_name
   when :xp_doge
     json["result"]["LastPrice"]
-  when :doge_btc
-    json["BTC_DOGE"]["last"]
-  when :btc_jpy
-    json["rate"]
   when :cmc_xp_jpy
     json[0]["price_jpy"]
   end

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -27,6 +27,8 @@ def read_url(coin_name)
     "https://poloniex.com/public?command=returnTicker"
   when :btc_jpy
     "https://coincheck.com/api/rate/btc_jpy"
+  when :cmc_xp_jpy
+    "https://api.coinmarketcap.com/v1/ticker/experience-points/?convert=JPY"
   end
 end
 
@@ -38,11 +40,14 @@ def read_price_from_json(coin_name, json)
     json["BTC_DOGE"]["last"]
   when :btc_jpy
     json["rate"]
+  when :cmc_xp_jpy
+    json[0]["price_jpy"]
   end
 end
 
 def xp_jpy
-  read_price(:xp_doge) * read_price(:doge_btc) * read_price(:btc_jpy)
+  # read_price(:xp_doge) * read_price(:doge_btc) * read_price(:btc_jpy)
+  read_price(:cmc_xp_jpy)
 end
 
 # -----------------------------------------------------------------------------

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -23,10 +23,6 @@ def read_url(coin_name)
   case coin_name
   when :xp_doge
     "https://www.coinexchange.io/api/v1/getmarketsummary?market_id=137"
-  when :doge_btc
-    "https://poloniex.com/public?command=returnTicker"
-  when :btc_jpy
-    "https://coincheck.com/api/rate/btc_jpy"
   when :cmc_xp_jpy
     "https://api.coinmarketcap.com/v1/ticker/experience-points/?convert=JPY"
   end
@@ -46,7 +42,6 @@ def read_price_from_json(coin_name, json)
 end
 
 def xp_jpy
-  # read_price(:xp_doge) * read_price(:doge_btc) * read_price(:btc_jpy)
   read_price(:cmc_xp_jpy)
 end
 
@@ -141,7 +136,7 @@ bc.include! Actions::Events::JoinAnnouncer
 bc.include! Actions::Events::CommandPatroller
 
 bc.include! Actions::Messages::Balance
-bc.include! Actions::Messages::Register
+#bc.include! Actions::Messages::Register
 bc.include! Actions::Messages::Hayo
 bc.include! Actions::Messages::Wayo
 


### PR DESCRIPTION
### 何を解決するのか

CoinExchangeのAPIがなかなか復活しないのでcoinmarketcapからJPY換算を取得するように変更しました。

@xpjp/ruby-reviewer レビューお願いします。