### PR TITLE
Bump up Ruby 2.5.0 (CI)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - "vendor/**/*" # rubocop config/default.yml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.3
+  - 2.5.0
 bundler_args: "-j4"
 cache: bundler
 script: bundle exec rubocop -a


### PR DESCRIPTION
### 何を解決するのか

Travis CI 上で使う Ruby のバージョンを 2.5.0 にします

### レビューポイント

- bump up します

