### PR TITLE
Xp-Bot系コマンドの警告を出すチャンネルを調整

### DIFF
--- a/lib/actions/events/command_patroller.rb
+++ b/lib/actions/events/command_patroller.rb
@@ -13,13 +13,25 @@ module Actions
     module CommandPatroller
       extend Discordrb::EventContainer
       @patroll_config = YAML.load_file("./patroll.yml")
-      message do |event|
+      message(start_with: ",") do |event|
         # apiの仕様的に存在しないことが保証されているかわからなかったので、落ちないように一応ガード節
-        break if !event.message || !event.channel || !event.user
+        next if !event.message || !event.channel || !event.user
 
-        needs_to_warn = @patroll_config["target_commands"].include?(event.message.content) &&
-                        !@patroll_config["allowed_channels"].include?(event.channel.name) # railsのexclude?使いたい
-        event.respond "#{event.user.mention} #{@patroll_config['warning_text']}" if needs_to_warn
+        command = event.message.content.strip.split(" ")[0]
+        no_prefix_command = command.split(",")[1]
+        next unless no_prefix_command
+
+        # 監視対象のコマンドが許可されているかを確認
+        is_restricted_command = @patroll_config["target_commands"].include?(command)
+        next unless is_restricted_command
+        permitted_commands = @patroll_config["allowed_channels"][event.channel.id].try(:[], "permitted_commands")
+        is_permitted = permitted_commands&.include?(command)
+
+        warning_text = <<~HEREDOC
+          #{no_prefix_command} はここではなく <##{@patroll_config['reccomended_channels'][no_prefix_command]}> でしてください。
+          ご協力ありがとうございます。"
+        HEREDOC
+        event.respond "#{event.user.mention} #{warning_text}" unless is_permitted
       end
     end
   end

--- a/lib/actions/events/command_patroller.rb
+++ b/lib/actions/events/command_patroller.rb
@@ -28,8 +28,7 @@ module Actions
         is_permitted = permitted_commands&.include?(command)
 
         warning_text = <<~HEREDOC
-          #{no_prefix_command} はここではなく <##{@patroll_config['reccomended_channels'][no_prefix_command]}> でしてください。
-          ご協力ありがとうございます。"
+          #{no_prefix_command} は <##{@patroll_config['reccomended_channels'][no_prefix_command]}> で実行をお願いします。
         HEREDOC
         event.respond "#{event.user.mention} #{warning_text}" unless is_permitted
       end

--- a/lib/actions/messages/register.rb
+++ b/lib/actions/messages/register.rb
@@ -6,10 +6,17 @@ module Actions
   module Messages
     module Register
       extend Discordrb::EventContainer
-
+      @patroll_config = YAML.load_file("./patroll.yml")
       message(start_with: ",register") do |event|
-        event.respond "#{event.user.mention} ウォレットは登録されました。利用できるよう準備を行っております。"
-        + "しばらく時間を置いてから <#390058691845554177> で`,balanceを`して確認してください。"
+        next unless @patroll_config["reccomended_channels"]["register"] == event.channel.id
+
+        balance_channel_id = @patroll_config["reccomended_channels"]["balance"]
+        message = <<~HEREDOC
+          #{event.user.mention} ウォレットは登録されました。
+          利用できるよう準備を行っております。しばらく時間を置いてから <##{balance_channel_id}> で`,balance`を実行して確認してください。
+        HEREDOC
+
+        event.respond message
       end
     end
   end

--- a/patroll.yml
+++ b/patroll.yml
@@ -8,8 +8,8 @@ target_commands:
   - ",balance"
   - ",deposit"
   - ",withdraw"
-  - ",rain"
-  - ",tip"
+  # - ",rain"
+  # - ",tip"
 
 # 各コマンドの推奨チャンネル
 reccomended_channels:

--- a/patroll.yml
+++ b/patroll.yml
@@ -2,19 +2,41 @@
 # 本来のチャネル以外でコマンドを実行すると警告を発する機能の設定ファイル
 ########################################################################
 
-# 注意文言
-warning_text: "balanceはここではなく <#390058691845554177> でしてください。\nご協力ありがとうございます。"
 # 監視対象のコマンド一覧
-# Prefixが変更になったときに変更の必要があるのでそのとき考える
 target_commands:
-#  - ",register"
+  - ",register"
   - ",balance"
-# コマンドを実行しても良いチャネルを登録
-# 厳しすぎる場合は禁止チャネルを指定する方向にシフト
-# (とはいえ、warningが飛ぶだけで実行できないわけではないのでこれでも良いかもしれない）
+  - ",deposit"
+  - ",withdraw"
+  - ",rain"
+  - ",tip"
+
+# 各コマンドの推奨チャンネル
+reccomended_channels:
+  register: 390074030834712576
+  balance: 375532870376357889
+  deposit: 390058691845554177
+  withdraw: 390058691845554177
+  rain: 379064989270540300
+  tip: 379064989270540300
+
+# 監視対象のコマンドを実行できるチャンネル
 allowed_channels:
-#  - "experiment" # 開発用
-#  - "register-room"
-  - "bot-spam"
-  - "bot-spam2"
-  - "bot_control"
+  390074030834712576:
+    name: "xpbot_register"
+    permitted_commands:
+      - ",register"
+  375532870376357889:
+    name: "xpbot_balance"
+    permitted_commands:
+      - ",balance"
+  390058691845554177:
+    name: "xpbot_deposit_withdraw"
+    permitted_commands:
+      - ",deposit"
+      - ",withdraw"
+  379064989270540300:
+    name: "xpbot_rain_tip"
+    permitted_commands:
+      - ",rain"
+      - ",tip"

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -51,7 +51,6 @@ end
 
 # -----------------------------------------------------------------------------
 def xp2jpy(event)
-  # rubocop:disable Style/FormatStringToken
   message = <<~HEREDOC
     #{event.user.mention}
     ただいま `?いくら` コマンドはサーバーへの過負荷により動作を停止しています。


### PR DESCRIPTION
### 何を解決するのか
Fix https://github.com/xpjp/xpfiat-bot/issues/103

### レビューポイント
動作確認は一通りしていますが、想定できていない text 入力があるかもしれないので、そのあたり意識していただければ助かります。

### ToDo
 - [x] `,register` コマンドを許可していない room で、「ウォレットは登録されました」のメッセージを出さないようにする。
 - [x] 動作確認