### PR TITLE
XPPay用に日本円でXPがどれだけ必要か調べる機能を追加

### DIFF
--- a/lib/actions/commands/xp_jpy.rb
+++ b/lib/actions/commands/xp_jpy.rb
@@ -9,7 +9,7 @@ module Actions
       extend Discordrb::Commands::CommandContainer
 
       command [:xp_jpy, :いくら] do |event, _param|
-        xp2jpy(event)
+        xp2jpy(event, _param)
        end
     end
   end

--- a/lib/actions/commands/xp_jpy.rb
+++ b/lib/actions/commands/xp_jpy.rb
@@ -8,7 +8,9 @@ module Actions
     module XpJpy
       extend Discordrb::Commands::CommandContainer
 
-      command [:xp_jpy, :いくら] { |event, _param| xp2jpy(event) }
+      command [:xp_jpy, :いくら] do |event, _param|
+        xp2jpy(event)
+       end
     end
   end
 end

--- a/lib/actions/commands/xp_jpy.rb
+++ b/lib/actions/commands/xp_jpy.rb
@@ -10,7 +10,7 @@ module Actions
 
       command [:xp_jpy, :いくら] do |event, _param|
         xp2jpy(event, _param)
-       end
+      end
     end
   end
 end

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -46,7 +46,8 @@ def xp_jpy
 end
 
 # -----------------------------------------------------------------------------
-def xp2jpy(event)
+def xp2jpy(event,_param)
+
   message = <<~HEREDOC
     #{event.user.mention}
     ただいま `?いくら` コマンドはサーバーへの過負荷により動作を停止しています。
@@ -63,6 +64,19 @@ def xp2jpy(event)
     Android
     <https://goo.gl/vQBg8R>
   HEREDOC
+
+  # XPPayサーバーとchipstarのテストサーバーでいくらコマンドを許可
+  sever_id = event.server.id
+  if sever_id == 388106353882693633 || sever_id == 404118276264951808
+    _time_now = Time.now.in_time_zone("Asia/Tokyo")
+    unit_price = xp_jpy()
+    price = ""
+    if _param
+      price = _param.to_f / unit_price
+      price = "#{_param}円はおおよそ `#{format('%.3f', price).to_f.to_s(:delimited)}XP` "
+    end
+    message = "#{price}(CMCの参考価格1XP = #{format('%.3f', unit_price.to_s(:delimited))}円[#{_time_now.strftime('%H:%M:%S')}])\n※この価格はCoinMarketCap(<https://coinmarketcap.com>)のAPIから取得した参考価格です。取引所の価格と異なる場合があります。"
+  end
   # rubocop:enable Style/FormatStringToken
   event.respond message
 end

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -65,8 +65,7 @@ def xp2jpy(event, param = 0)
   HEREDOC
 
   # XPPayサーバーとchipstarのテストサーバーでいくらコマンドを許可
-  allow_servers = [388_106_353_882_693_633, 404_118_276_264_951_808]
-  if allow_servers.include?(event.server.id)
+  if [388_106_353_882_693_633, 404_118_276_264_951_808].include?(event.server.id)
     _time_now = Time.now.in_time_zone("Asia/Tokyo")
     price = "#{param}円はおおよそ `#{format('%.3f', (param.to_f / xp_jpy)).to_f.to_s(:delimited)}XP` " unless param.nil?
     message = <<~HEREDOC

--- a/xp_fiat.rb
+++ b/xp_fiat.rb
@@ -46,8 +46,7 @@ def xp_jpy
 end
 
 # -----------------------------------------------------------------------------
-def xp2jpy(event,_param)
-
+def xp2jpy(event, param = 0)
   message = <<~HEREDOC
     #{event.user.mention}
     ただいま `?いくら` コマンドはサーバーへの過負荷により動作を停止しています。
@@ -66,16 +65,14 @@ def xp2jpy(event,_param)
   HEREDOC
 
   # XPPayサーバーとchipstarのテストサーバーでいくらコマンドを許可
-  sever_id = event.server.id
-  if sever_id == 388106353882693633 || sever_id == 404118276264951808
+  allow_servers = [388_106_353_882_693_633, 404_118_276_264_951_808]
+  if allow_servers.include?(event.server.id)
     _time_now = Time.now.in_time_zone("Asia/Tokyo")
-    unit_price = xp_jpy()
-    price = ""
-    if _param
-      price = _param.to_f / unit_price
-      price = "#{_param}円はおおよそ `#{format('%.3f', price).to_f.to_s(:delimited)}XP` "
-    end
-    message = "#{price}(CMCの参考価格1XP = #{format('%.3f', unit_price.to_s(:delimited))}円[#{_time_now.strftime('%H:%M:%S')}])\n※この価格はCoinMarketCap(<https://coinmarketcap.com>)のAPIから取得した参考価格です。取引所の価格と異なる場合があります。"
+    price = "#{param}円はおおよそ `#{format('%.3f', (param.to_f / xp_jpy)).to_f.to_s(:delimited)}XP` " unless param.nil?
+    message = <<~HEREDOC
+      #{price}(CMCの参考価格1XP = #{format('%.3f', xp_jpy.to_s(:delimited))}円[#{_time_now.strftime('%H:%M:%S')}])
+      ※この価格はCoinMarketCap(<https://coinmarketcap.com>)のAPIから取得した参考価格です。取引所の価格と異なる場合があります。
+    HEREDOC
   end
   # rubocop:enable Style/FormatStringToken
   event.respond message


### PR DESCRIPTION
### 何を解決するのか
XPPayサーバー用に日本円でXPがどれだけ必要かを調べられるようにしました。
急ぎみたいだったのでデプロイ済みです。

